### PR TITLE
refactor: update prerender-node to v3.4.1

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,12 +1,12 @@
 Package.describe({
   name: 'mdg:seo',
   summary: 'Provide SEO support for enabled apps.',
-  version: '3.2.2',
+  version: '3.2.3',
   git: 'https://github.com/meteor/galaxy-seo-package',
 });
 
 Npm.depends({
-  'prerender-node': '3.2.5',
+  'prerender-node': '3.4.1',
 });
 
 Package.onUse(function packageConfiguration(api) {


### PR DESCRIPTION
The new version of prerender-node contains more user bots agents
(e.g. newly merged [PR](https://github.com/prerender/prerender-node/pull/222) with seznambot https://www.seznam.cz/)

I tested this on my server, galaxy-seo with this updated prerender-node seems to be working fine