### PR TITLE
Add support for missing prerender-node options

### DIFF
--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -2,9 +2,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "prerender-node": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/prerender-node/-/prerender-node-3.4.1.tgz",
-      "integrity": "sha512-gcR5ykf8mYewdI2SBcfjgm11AcS6QZyW/vJwD7uSivA1qV5nUvku7Kw9+cukQTKn746efTEjQxIlM787esOJ0w=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/prerender-node/-/prerender-node-3.5.0.tgz",
+      "integrity": "sha512-sx+ONyy3meEPmlixmeezcOSNg45Z9hzlUN5R6STPHzllWtf5EUBWh6lRV8/29IzPI+VWqIJ32EeV/5JbjvbSKg=="
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.4.0
 - Update prerender-node to 3.5.0
+- Add support for missing prerender-node options: forwardHeaders, prerenderServerRequestOptions, whitelist and blocklist
 
 ## 3.3.0 (2022-01-25)
 - Update prerender-node to 3.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 3.4.0
+- Update prerender-node to 3.5.0
+
 ## 3.3.0 (2022-01-25)
 - Update prerender-node to 3.4.1
 - Modernize code

--- a/README.md
+++ b/README.md
@@ -16,8 +16,14 @@ In your settings.json file, include:
 ```
 {
   "PrerenderIO": {
+    # Required
+    "token": "yourtoken" # You need to provide anything here for local server support
+    # Optional
     "serviceUrl": "http://localhost:3033/",
-    "token": "yourtoken"
+    "forwardHeaders": true,
+    "serverRequestOptions": {},
+    "allowList": ["^/(\\?.+)?$", "/dashboard"],
+    "blockList": ["^/search"],
   }
 }
 ```
@@ -25,7 +31,18 @@ In your settings.json file, include:
 The `serviceURL` is optional and only used to test the Prerender server locally.
 Leave it out in your production configuration.
 
-*NOTICE*: You may also provide the above credentials using environment variables, namely `PRERENDERIO_TOKEN` and `PRERENDERIO_SERVICE_URL`. They precede the configuration from the settings file.
+See [Prerender-node customization](https://www.npmjs.com/package/prerender-node#customization) for more details
+about options.
+
+*NOTICE*: You may also provide the above settings using environment variables:
+* `PRERENDERIO_TOKEN`
+* `PRERENDERIO_SERVICE_URL="http://localhost:3033/"`
+* `PRERENDERIO_FORWARD_HEADERS="true"`
+* `PRERENDERIO_SERVER_REQUEST_OPTIONS="{}"`
+* `PRERENDERIO_ALLOW_LIST="[]"`
+* `PRERENDERIO_BLOCK_LIST="[]"`
+
+They precede the configuration from the settings file.
 
 ## Testing and Verifying
 There are two options to test whether Prerender is working or not.

--- a/package.js
+++ b/package.js
@@ -3,12 +3,12 @@
 Package.describe({
   name: 'mdg:seo',
   summary: 'Provide SEO support for enabled apps.',
-  version: '3.3.0',
+  version: '3.4.0',
   git: 'https://github.com/meteor/galaxy-seo-package',
 });
 
 Npm.depends({
-  'prerender-node': '3.4.1',
+  'prerender-node': '3.5.0',
 });
 
 Package.onUse(function packageConfiguration(api) {

--- a/server/prerender.js
+++ b/server/prerender.js
@@ -7,10 +7,24 @@ const settings = Meteor.settings.PrerenderIO;
 
 const token = process.env.PRERENDERIO_TOKEN || (settings && settings.token);
 const protocol = process.env.PRERENDERIO_PROTOCOL || (settings && settings.protocol);
+const forwardHeaders = process.env.PRERENDERIO_FORWARD_HEADERS
+  ? process.env.PRERENDERIO_FORWARD_HEADERS.toLowerCase() === 'true'
+  : (settings && settings.forwardHeaders);
+const serverRequestOptions = process.env.PRERENDERIO_SERVER_REQUEST_OPTIONS
+  ? JSON.parse(process.env.PRERENDERIO_SERVER_REQUEST_OPTIONS)
+  : (settings && settings.serverRequestOptions);
 
 // service url (support `prerenderServiceUrl` (for historical reasons) and `serviceUrl`)
 const serviceUrlFromSettings = settings && (settings.prerenderServiceUrl || settings.serviceUrl);
 const serviceUrl = process.env.PRERENDERIO_SERVICE_URL || serviceUrlFromSettings;
+
+// Block and allow list support
+const allowList = process.env.PRERENDERIO_ALLOW_LIST
+? JSON.parse(process.env.PRERENDERIO_ALLOW_LIST)
+: (settings && settings.allowList);
+const blockList = process.env.PRERENDERIO_BLOCK_LIST
+  ? JSON.parse(process.env.PRERENDERIO_BLOCK_LIST)
+  : (settings && settings.blockList);
 
 
 if (token) {
@@ -22,6 +36,20 @@ if (token) {
 
   if (protocol) {
     prerenderio.set('protocol', protocol);
+  }
+
+  prerenderio.set('forwardHeaders', forwardHeaders);
+
+  if (serverRequestOptions) {
+    prerenderio.set('prerenderServerRequestOptions', serverRequestOptions);
+  }
+
+  if (Array.isArray(allowList) && allowList.length > 0) {
+    prerenderio.whitelisted(allowList);
+  }
+
+  if (Array.isArray(blockList) && blockList.length > 0) {
+    prerenderio.blacklisted(blockList);
   }
 
   prerenderio.set('afterRender', function afterRender(error) {


### PR DESCRIPTION
Hi!

I really like this package and I find it incredibly useful for simple SEO optimization. I missed a few options that are necessary for my configuration, so I figured "why not add it myself and contribute to the project?" :wink: 

Brief list of changes:
* upgraded `prerender-node` to 3.5.0
* added support for:
  * `whitelisted` (with a change to `allowList`), 
  * `blacklisted` (with a change to `blockList`), 
  * `forwardHeaders`,
  * `prerenderServerRequestOptions` (with a change to simply `serverRequestOptions`).

I hope you'll find this useful and merge the changes soon :+1: 

EDIT: I also found an issue that this PR solves: https://github.com/meteor/galaxy-seo-package/issues/4